### PR TITLE
require actual inputs to be non-blank

### DIFF
--- a/view.js
+++ b/view.js
@@ -11,7 +11,10 @@ function inquireForInput(message, complete) {
     inquirer.prompt([{
         type: 'input',
         name: 'input',
-        message: message}],
+        message: message,
+        validate: function(input) {
+          return input.trim().length !== 0;
+        }}],
         function(response) {
             confirmInquire(response.input, function(err, confirmed) {
                 if (err) return inquireForInput(message, complete);


### PR DESCRIPTION
`inquireForInput` is used in two places, github auth and entering pair partner name, where input should always be expected.

yields
? Enter your GitHub username:

> > Please enter a valid value
