### PR TITLE
Feat/ci cd pipe

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,21 @@
+# !!!! THIS DOES NOT BUMP THE PACKAGE VERSION
+name: Npm Publish
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+      - run: npm login --scope=${{secrets.NPM_EMAIL}}
+      - run: npm install
+      - run: npm publish
+      - run: npm logout --scope=${{secrets.NPM_EMAIL}}
+    env:
+      NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+# https://javascript.plainenglish.io/publish-update-npm-packages-with-github-actions-e4d786ffd62a

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,23 +1,22 @@
 # !!!! THIS DOES NOT BUMP THE PACKAGE VERSION
-name: Npm Publish
 
+name: Publish Package to npmjs
 on:
   release:
-    types: [published]
-
+    types: [created]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14
-          registry-url: https://registry.npmjs.org/
-      - run: npm install
-      - uses: JS-DevTools/npm-publish@v1
-        with:
-          dry-run: true # use this for testing
-          token: ${{ secrets.NPM_AUTH_TOKEN }}
+          node-version: "14"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm publish --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 # https://javascript.plainenglish.io/publish-update-npm-packages-with-github-actions-e4d786ffd62a
 # https://github.com/marketplace/actions/npm-publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,7 +1,9 @@
 # !!!! THIS DOES NOT BUMP THE PACKAGE VERSION
 name: Npm Publish
 
-on: [push]
+on:
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -12,10 +14,10 @@ jobs:
         with:
           node-version: 14
           registry-url: https://registry.npmjs.org/
-      - run: npm login --scope=${{secrets.NPM_EMAIL}}
       - run: npm install
-      - run: npm publish
-      - run: npm logout --scope=${{secrets.NPM_EMAIL}}
-    env:
-      NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          dry-run: true # use this for testing
+          token: ${{ secrets.NPM_AUTH_TOKEN }}
 # https://javascript.plainenglish.io/publish-update-npm-packages-with-github-actions-e4d786ffd62a
+# https://github.com/marketplace/actions/npm-publish

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ index.html
 files.json
 project-lock.json
 test/files/environment/projects
+.secrets

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "windows-dev": "dos2unix ./install.sh",
     "dev": "nodemon test-server.js",
     "test": "mocha ./test",
-    "preinstall": "npx npm-force-resolutions"
+    "preinstall": "npx npm-force-resolutions",
+    "test:publish": "act release -W .github/workflows/npm-publish.yml"
   },
   "resolutions": {
     "graceful-fs": "^4.2.9"


### PR DESCRIPTION
uses github actions to automate the publishing process
Note:
 this process does not change the version number and should fail when it is not bumped up
the dry-run key must be commented out for it to publish otherwise it will default as a test run
